### PR TITLE
Add student login and dashboard placeholder

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
+import TeacherApp from './teacher/TeacherApp'
 import './index.css' // 이 줄이 반드시 있어야 합니다!
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <TeacherApp />
   </React.StrictMode>,
 )

--- a/src/teacher/Login.tsx
+++ b/src/teacher/Login.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+
+interface Props {
+  onLoginSuccess: () => void;
+}
+
+const Login: React.FC<Props> = ({ onLoginSuccess }) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setError(null);
+    try {
+      const auth = getAuth();
+      await signInWithEmailAndPassword(auth, email, password);
+      onLoginSuccess();
+    } catch (e) {
+      const err = e as Error;
+      setError(err.message);
+    }
+  };
+
+  const handleSignup = async () => {
+    setError(null);
+    try {
+      const auth = getAuth();
+      await createUserWithEmailAndPassword(auth, email, password);
+      onLoginSuccess();
+    } catch (e) {
+      const err = e as Error;
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="bg-white shadow-md rounded p-6 w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-bold text-center">Student Login</h1>
+        <input
+          type="email"
+          className="w-full border p-2 rounded"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          className="w-full border p-2 rounded"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div className="flex gap-2">
+          <button
+            className="flex-1 bg-blue-600 text-white p-2 rounded"
+            onClick={handleLogin}
+          >
+            Login
+          </button>
+          <button
+            className="flex-1 bg-green-600 text-white p-2 rounded"
+            onClick={handleSignup}
+          >
+            Sign Up
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/teacher/StudentDashboard.tsx
+++ b/src/teacher/StudentDashboard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const StudentDashboard: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-bold">Welcome to your dashboard!</h2>
+      <p className="mt-2 text-gray-700">This area will show student information and progress.</p>
+    </div>
+  );
+};
+
+export default StudentDashboard;

--- a/src/teacher/TeacherApp.tsx
+++ b/src/teacher/TeacherApp.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { initializeApp } from 'firebase/app';
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import Login from './Login';
+import StudentDashboard from './StudentDashboard';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+};
+
+initializeApp(firebaseConfig);
+
+const TeacherApp: React.FC = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const auth = getAuth();
+    return onAuthStateChanged(auth, user => {
+      setIsLoggedIn(!!user);
+    });
+  }, []);
+
+  if (!isLoggedIn) {
+    return <Login onLoginSuccess={() => setIsLoggedIn(true)} />;
+  }
+
+  return <StudentDashboard />;
+};
+
+export default TeacherApp;


### PR DESCRIPTION
## Summary
- build a simple login form using Firebase auth
- show a placeholder dashboard after login
- add a TeacherApp that switches between login and dashboard
- render the new TeacherApp from `main.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68710656db30832d91a978f8505786b3